### PR TITLE
Add xml shortcut

### DIFF
--- a/http.js
+++ b/http.js
@@ -78,5 +78,20 @@ module.exports = function(should, Assertion) {
   Assertion.add('html', function() {
     this.have.header('content-type').match(/text\/html/i);
   });
+
+  /**
+   * Shortcut for .should.header('content-type', 'application/xml')
+   *
+   * @name xml
+   * @memberOf Assertion
+   * @category assertion http
+   * @module should-http
+   * @example
+   *
+   * res.should.be.xml();
+   */
+  Assertion.add('xml', function() {
+    this.have.header('content-type').match(/application\/xml/i);
+  });
 };
 

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -43,6 +43,34 @@ describe('http', function() {
     ({}).should.not.be.json();
   });
 
+  it('test .xml', function(){
+    var req = {
+      headers: {
+        'content-type': 'application/xml'
+      }
+    };
+
+    req.should.be.xml();
+
+    req = {
+      headers: {
+        'content-type': 'application/xml; charset=utf-8'
+      }
+    };
+
+    req.should.be.xml();
+
+    req = {
+      headers: {
+        'content-type': 'text/html'
+      }
+    };
+
+    req.should.not.be.xml();
+
+    ({}).should.not.be.xml();
+  });
+
   it('test .status', function() {
     ({ statusCode: 300 }).should.have.not.status(200);
 


### PR DESCRIPTION
Adds an extra helper for xml: `res.should.be.xml()`.